### PR TITLE
Fix require paths for Webpack/browserify support

### DIFF
--- a/lib/extender.js
+++ b/lib/extender.js
@@ -14,8 +14,8 @@ var util = require('util'),
     _ = require('lodash'),
     hoek = require('hoek'),
     joi = require('joi'),
-    Any = require(path.join(__dirname, '../node_modules/joi/lib/any')),
-    Errors = require(path.join(__dirname, '../node_modules/joi/lib/errors'));
+    Any = require('joi/lib/any'),
+    Errors = require('joi/lib/errors');
 
 /**
  * @module joiExtender


### PR DESCRIPTION
The calculated paths prevent this module from compiling in webpack.
